### PR TITLE
Changed the way the default task is chosen.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -130,7 +130,7 @@ class KatanaEngine(tank.platform.Engine):
         :rtype: :class:`tank.context.Context`
         '''
         if context.project:
-            if not context.entity:
+            if not context.entity and self._ui_enabled:
                 newContext = self.userChosenContext(tk, context)
                 return newContext
             elif context.entity and not context.task:
@@ -138,7 +138,7 @@ class KatanaEngine(tank.platform.Engine):
                 if task:
                     newContext = tk.context_from_entity('Task', task['id'])
                     return newContext
-                else:
+                elif self._ui_enabled:
                     newContext = self.userChosenContext(tk, context)
                     return newContext
             else:


### PR DESCRIPTION
(For assets, just replace lighting by shading)
Automatic choosing of a task has now this logic:

A/ no lighting step tasks: the user needs to choose from the task chooser
B/ 1 lighting step task: gets selected
C/ more than one:
    a) only one where the user is assigned: gets selected
    b) zero where the user is assigned, or more than one: the user has to select one manually.

**Relationship with other PRs (with links!)**

wg_katana: https://bitbucket.org/rodeofx/wg_katana/pull-requests/6/mon-dev-katana-fix-taskchooser-rdev-6200/diff

tk-multi-contextSwitcher: https://bitbucket.org/rodeofx/tk-multi-contextswitcher/pull-requests/3/mon-context-switcher-now-working-with/diff