### PR TITLE
[WED] Hotfix repair menu callbacks

### DIFF
--- a/python/tk_katana/menu_generation.py
+++ b/python/tk_katana/menu_generation.py
@@ -279,14 +279,15 @@ class AppCommand(object):
 
     def do_add_command(self, menu, name, cmd, hot_key=None, icon=None):
         # TODO add hot key
+        cb = lambda: cmd()
         if hot_key:
-            action = QtGui.QAction(name, menu, triggered=cmd, icon=icon)
+            action = QtGui.QAction(name, menu, triggered=cb, icon=icon)
         else:
             if icon:
                 new_icon = QtGui.QIcon(icon)
-                action = QtGui.QAction(name, menu, triggered=cmd, icon=new_icon)
+                action = QtGui.QAction(name, menu, triggered=cb, icon=new_icon)
             else:
-                action = QtGui.QAction(name, menu, triggered=cmd)
+                action = QtGui.QAction(name, menu, triggered=cb)
         menu.addAction(action)
 
     def add_command_to_menu(self, menu):

--- a/python/tk_katana/menu_generation.py
+++ b/python/tk_katana/menu_generation.py
@@ -279,6 +279,20 @@ class AppCommand(object):
 
     def do_add_command(self, menu, name, cmd, hot_key=None, icon=None):
         # TODO add hot key
+
+        # From the PyQt documentation:
+        # PySide.QtGui.QAction.triggered([checked = false])
+        # Parameters:    checked – PySide.QtCore.bool
+        # If your callback signature is cmd(*args), the signal sent will have an arg, False, which corresponds
+        # to the checked state of the menu item. But if it's cmd(), then it won't.
+        # since the apps registered commands are defined as wrappers, callback_wrapper(*args, **kwargs)
+        #  (see /rdo/rodeo/repositories/tank/studio/install/core/python/tank/platform/engine.py,
+        # register_command function), they will pass the False argument to the callbacks registered by the
+        # apps, for example for tk-multi-contextSwitcher:
+        # menu_callback = lambda : app_payload.contextSwitcher.show_dialog(self)
+        # this will fail since the callback does not take any arguments.
+        # By "wrapping the wrapper" with this lambda, the function attached to triggered has no args and
+        # everything works.
         cb = lambda: cmd()
         if hot_key:
             action = QtGui.QAction(name, menu, triggered=cb, icon=icon)


### PR DESCRIPTION
Menu callbacks for the Shotgun menu are broken:
The register_command of an engine used by an app:
`menu_callback = lambda : app_payload.contextSwitcher.show_dialog(self)`
`command = self.engine.register_command("Context Switcher", menu_callback)`
is in every app passed in some form to Qt menus (for the shotgun menu)
In tk-katana/python/tk-katana/menu_generation.py:
`action = QtGui.QAction(name, menu, triggered=cmd, icon=icon)`
`menu.addAction(action)`

then normally when you click on the menu entry, it sends a signal, which executes the command.
This is the standard way most apps (ours and from the toolkit) are made.

After the upgrade, it seems the way these signals are handled has changed, but I guess only for Katana (which seems weird), because it's passing an extra argument:
`[ERROR python.root]: A TypeError occurred in "engine.py": <lambda>() takes no arguments (1 given)`
the argument given is False, and Greg and I have investigated, and it's the standard behaviour:
http://pyqt.sourceforge.net/Docs/PyQt4/qaction.html#triggered

So I "added a wrapper around the wrapper":
`cb = lambda: cmd()`
that works, not sure if some apps do have args. I think they don't
