### PR TITLE
RTD-706: add env and other cg steps to tk-katana

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -186,7 +186,7 @@ class KatanaEngine(tank.platform.Engine):
 
 
     def userChosenContext(self, tk, context):
-        stepShortNames = ['Lgt', 'Shd', 'FX']
+        stepShortNames = ['Ani', 'CFX', 'Crowd', 'ENV', 'FX', 'Lay', 'Lgt', 'Model', 'Previs', 'Rig', 'Std', 'Shd', 'Tex']
         tc = taskChooser.TaskChooser(context, stepShortNames)
         status = tc.exec_()
         if status == 0: # value of PyQt4.QtGui.QDialog.Rejected. We do not want to import that module at this point.

--- a/python/tk_katana/menu_generation.py
+++ b/python/tk_katana/menu_generation.py
@@ -282,7 +282,7 @@ class AppCommand(object):
 
         # From the PyQt documentation:
         # PySide.QtGui.QAction.triggered([checked = false])
-        # Parameters:    checked – PySide.QtCore.bool
+        # Parameters:    checked - PySide.QtCore.bool
         # If your callback signature is cmd(*args), the signal sent will have an arg, False, which corresponds
         # to the checked state of the menu item. But if it's cmd(), then it won't.
         # since the apps registered commands are defined as wrappers, callback_wrapper(*args, **kwargs)


### PR DESCRIPTION
**Purpose of the PR / What does this do?**
 - This adds env and other cg steps to the tk-katana app.

**Overview of the changes (don't assume any history)**
- Changed the config of the task steps that are used for the context switcher.

**Type of feedback wanted**
  - A quick pair of eyes on the code.

**Where should the reviewer start looking at?**
 - In the userChosenContext() function where the steps short name are defined.

**Potential risks of this change, if any.**
 
**Relationship with other PRs (with links!)**